### PR TITLE
Replace owner with /ROKT/ for easier builds

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -7,7 +7,7 @@ import (
 	"path"
 
 	"github.com/cloudquery/cq-provider-sdk/provider/docs"
-	"github.com/cloudquery/cq-provider-template/resources/provider"
+	"github.com/ROKT/cq-provider-template/resources/provider"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cloudquery/cq-provider-template
+module github.com/ROKT/cq-provider-template
 
 go 1.18
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/cloudquery/cq-provider-sdk/serve"
-	"github.com/cloudquery/cq-provider-template/resources/provider"
+	"github.com/ROKT/cq-provider-template/resources/provider"
 )
 
 func main() {

--- a/resources/provider/provider.go
+++ b/resources/provider/provider.go
@@ -4,8 +4,8 @@ import (
 	"github.com/cloudquery/cq-provider-sdk/provider"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 	// CHANGEME: change the following to your own package
-	"github.com/cloudquery/cq-provider-template/client"
-	"github.com/cloudquery/cq-provider-template/resources/services/demo"
+	"github.com/ROKT/cq-provider-template/client"
+	"github.com/ROKT/cq-provider-template/resources/services/demo"
 )
 
 var (

--- a/resources/services/demo/gen.hcl
+++ b/resources/services/demo/gen.hcl
@@ -7,13 +7,13 @@ description_modifier "remove_read_only" {
 }
 
 resource "demo" "domain" "resource" {
-  path = "github.com/cloudquery/cq-provider-template/resources/services/demo.Resource"
+  path = "github.com/ROKT/cq-provider-template/resources/services/demo.Resource"
 
   userDefinedColumn "account_id" {
     type        = "string"
     description = "The AWS Account ID of the resource."
     resolver "resolveAWSAccount" {
-      path   = "github.com/cloudquery/cq-provider-template/resources/services/demo.ResolverPath"
+      path   = "github.com/ROKT/cq-provider-template/resources/services/demo.ResolverPath"
       params = ["AccountId"]
     }
   }
@@ -21,7 +21,7 @@ resource "demo" "domain" "resource" {
     type        = "string"
     description = "The AWS Region of the resource."
     resolver "demoResolver" {
-      path = "github.com/cloudquery/cq-provider-template/resources/services/demo.Resolver"
+      path = "github.com/ROKT/cq-provider-template/resources/services/demo.Resolver"
     }
   }
 


### PR DESCRIPTION
### Background ###

Internal copy of CQ provider template.

### What Has Changed: ###

Replace /cloudquery/ with /ROKT/ for template paths to make adaption easier.

### How Has This Been Tested? ###

N/A

### Notes

### Checklist: ###

- [ ] Run `go fmt` to format your code.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have verified that CI completes successfully.
- [x] All insignificant commits have been squashed.
